### PR TITLE
chore: halogo-motorpass to 0.0.11

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -18,7 +18,7 @@ dependencies:
   version: 0.0.79
 - name: halogo-motorpass
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.9
+  version: 0.0.11
 - name: halogo-payment
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.3


### PR DESCRIPTION
chore: Promote halogo-motorpass to version 0.0.11