### PR TITLE
chore: halogo-vehicle to 0.0.162

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -33,4 +33,4 @@ dependencies:
   version: 0.0.5
 - name: halogo-vehicle
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.161
+  version: 0.0.162


### PR DESCRIPTION
chore: Promote halogo-vehicle to version 0.0.162